### PR TITLE
Feat/#7 Realm 연동 및 CRUD 테스트 작성

### DIFF
--- a/PomoLog.xcodeproj/project.pbxproj
+++ b/PomoLog.xcodeproj/project.pbxproj
@@ -6,14 +6,75 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		1899FF072EF3F79B00C74BAD /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1899FF062EF3F79B00C74BAD /* RealmSwift */; };
+		1899FF0A2EF3F7C800C74BAD /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1899FF092EF3F7C800C74BAD /* RealmSwift */; };
+		1899FF0B2EF3F7C800C74BAD /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 1899FF092EF3F7C800C74BAD /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		187742D42EF3F122006215C7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 180224762EE4602C00EFBD70 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1802247D2EE4602C00EFBD70;
+			remoteInfo = PomoLog;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		18773FF62EF3DA41006215C7 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		187742CE2EF3EA12006215C7 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				1899FF0B2EF3F7C800C74BAD /* RealmSwift in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		1802247E2EE4602C00EFBD70 /* PomoLog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PomoLog.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		18773FE62EF3D5BA006215C7 /* PomoLogTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PomoLogTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		189901DF2EF3FC1500C74BAD /* Exceptions for "PomoLog" folder in "PomoLogTest" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Data/DataBase.swift,
+				Data/RealmManager.swift,
+				Models/SummaryModel.swift,
+			);
+			target = 18773FE52EF3D5BA006215C7 /* PomoLogTest */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		180224802EE4602C00EFBD70 /* PomoLog */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				189901DF2EF3FC1500C74BAD /* Exceptions for "PomoLog" folder in "PomoLogTest" target */,
+			);
 			path = PomoLog;
+			sourceTree = "<group>";
+		};
+		18773FE72EF3D5BA006215C7 /* PomoLogTest */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = PomoLogTest;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -23,6 +84,15 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1899FF0A2EF3F7C800C74BAD /* RealmSwift in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		18773FE32EF3D5BA006215C7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1899FF072EF3F79B00C74BAD /* RealmSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -33,6 +103,8 @@
 			isa = PBXGroup;
 			children = (
 				180224802EE4602C00EFBD70 /* PomoLog */,
+				18773FE72EF3D5BA006215C7 /* PomoLogTest */,
+				187742D62EF3F270006215C7 /* Frameworks */,
 				1802247F2EE4602C00EFBD70 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -41,8 +113,16 @@
 			isa = PBXGroup;
 			children = (
 				1802247E2EE4602C00EFBD70 /* PomoLog.app */,
+				18773FE62EF3D5BA006215C7 /* PomoLogTest.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		187742D62EF3F270006215C7 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -55,6 +135,7 @@
 				1802247A2EE4602C00EFBD70 /* Sources */,
 				1802247B2EE4602C00EFBD70 /* Frameworks */,
 				1802247C2EE4602C00EFBD70 /* Resources */,
+				187742CE2EF3EA12006215C7 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -65,10 +146,36 @@
 			);
 			name = PomoLog;
 			packageProductDependencies = (
+				1899FF092EF3F7C800C74BAD /* RealmSwift */,
 			);
 			productName = PomoLog;
 			productReference = 1802247E2EE4602C00EFBD70 /* PomoLog.app */;
 			productType = "com.apple.product-type.application";
+		};
+		18773FE52EF3D5BA006215C7 /* PomoLogTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 18773FEA2EF3D5BA006215C7 /* Build configuration list for PBXNativeTarget "PomoLogTest" */;
+			buildPhases = (
+				18773FE22EF3D5BA006215C7 /* Sources */,
+				18773FE32EF3D5BA006215C7 /* Frameworks */,
+				18773FE42EF3D5BA006215C7 /* Resources */,
+				18773FF62EF3DA41006215C7 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				187742D52EF3F122006215C7 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				18773FE72EF3D5BA006215C7 /* PomoLogTest */,
+			);
+			name = PomoLogTest;
+			packageProductDependencies = (
+				1899FF062EF3F79B00C74BAD /* RealmSwift */,
+			);
+			productName = PomoLogTest;
+			productReference = 18773FE62EF3D5BA006215C7 /* PomoLogTest.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -83,6 +190,9 @@
 					1802247D2EE4602C00EFBD70 = {
 						CreatedOnToolsVersion = 16.2;
 					};
+					18773FE52EF3D5BA006215C7 = {
+						CreatedOnToolsVersion = 16.2;
+					};
 				};
 			};
 			buildConfigurationList = 180224792EE4602C00EFBD70 /* Build configuration list for PBXProject "PomoLog" */;
@@ -94,18 +204,29 @@
 			);
 			mainGroup = 180224752EE4602C00EFBD70;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				18773FC62EF39F36006215C7 /* XCRemoteSwiftPackageReference "realm-swift" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 1802247F2EE4602C00EFBD70 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				1802247D2EE4602C00EFBD70 /* PomoLog */,
+				18773FE52EF3D5BA006215C7 /* PomoLogTest */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		1802247C2EE4602C00EFBD70 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		18773FE42EF3D5BA006215C7 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -122,7 +243,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		18773FE22EF3D5BA006215C7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		187742D52EF3F122006215C7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1802247D2EE4602C00EFBD70 /* PomoLog */;
+			targetProxy = 187742D42EF3F122006215C7 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		1802248A2EE4602D00EFBD70 /* Debug */ = {
@@ -312,6 +448,46 @@
 			};
 			name = Release;
 		};
+		18773FEB2EF3D5BA006215C7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Z5J43V9D9J;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.heopaka.PomoLogTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = NO;
+				SUPPORTED_PLATFORMS = macosx;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		18773FEC2EF3D5BA006215C7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = Z5J43V9D9J;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.heopaka.PomoLogTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = NO;
+				SUPPORTED_PLATFORMS = macosx;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -333,7 +509,40 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		18773FEA2EF3D5BA006215C7 /* Build configuration list for PBXNativeTarget "PomoLogTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				18773FEB2EF3D5BA006215C7 /* Debug */,
+				18773FEC2EF3D5BA006215C7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		18773FC62EF39F36006215C7 /* XCRemoteSwiftPackageReference "realm-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/realm-swift";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		1899FF062EF3F79B00C74BAD /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 18773FC62EF39F36006215C7 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = RealmSwift;
+		};
+		1899FF092EF3F7C800C74BAD /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 18773FC62EF39F36006215C7 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = RealmSwift;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 180224762EE4602C00EFBD70 /* Project object */;
 }

--- a/PomoLog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PomoLog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "2174eaf93f622d57be865cd78b51b72620c12528f1f0957292620977c4d69891",
+  "pins" : [
+    {
+      "identity" : "realm-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-core.git",
+      "state" : {
+        "revision" : "cccb3ca9e26ec452a29f2f0d4050d1e38b8a3d43",
+        "version" : "14.14.0"
+      }
+    },
+    {
+      "identity" : "realm-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-swift",
+      "state" : {
+        "branch" : "master",
+        "revision" : "c22f9303d446fc3c044e4c151ed19597464b6bd7"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/PomoLog.xcodeproj/xcshareddata/xcschemes/PomoLogTest.xcscheme
+++ b/PomoLog.xcodeproj/xcshareddata/xcschemes/PomoLogTest.xcscheme
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "18773FE52EF3D5BA006215C7"
+               BuildableName = "PomoLogTest.xctest"
+               BlueprintName = "PomoLogTest"
+               ReferencedContainer = "container:PomoLog.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/PomoLog.xcodeproj/xcuserdata/apple.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/PomoLog.xcodeproj/xcuserdata/apple.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -4,10 +4,28 @@
 <dict>
 	<key>SchemeUserState</key>
 	<dict>
-		<key>PomoLog.xcscheme_^#shared#^_</key>
+		<key>GettingStarted (Playground).xcscheme</key>
 		<dict>
 			<key>orderHint</key>
 			<integer>0</integer>
+		</dict>
+		<key>PomoLog.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>1</integer>
+		</dict>
+		<key>PomoLogTest.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>18773FE52EF3D5BA006215C7</key>
+		<dict>
+			<key>primary</key>
+			<true/>
 		</dict>
 	</dict>
 </dict>

--- a/PomoLog/Data/DataBase.swift
+++ b/PomoLog/Data/DataBase.swift
@@ -1,0 +1,16 @@
+//
+//  DataBase.swift
+//  PomoLog
+//
+//  Created by APPLE on 12/18/25.
+//
+
+import RealmSwift
+
+protocol DataBase {
+    
+    func save<T: Object>(model: T) -> Bool
+    func fetchAll<T: Object>(_ type: T.Type) -> Results<T>?
+    func fetchById<T: Object>(id: ObjectId, _ type: T.Type) -> T?
+    func delete<T: Object>(id: ObjectId, _ type: T.Type) -> Bool
+}

--- a/PomoLog/Data/RealmManager.swift
+++ b/PomoLog/Data/RealmManager.swift
@@ -1,0 +1,47 @@
+//
+//  RealmManager.swift
+//  PomoLog
+//
+//  Created by APPLE on 12/18/25.
+//
+
+import RealmSwift
+
+final class RealmManager: DataBase {
+    
+    private let realm: Realm?
+    
+    init(realm: Realm? = try? Realm()) {
+        self.realm = realm
+    }
+    
+    func save<T>(model: T) -> Bool where T : Object {
+        let result: ()? = try? realm?.write {
+            // 이미 id가 존재하면 업데이트
+            realm?.add(model, update: .modified)
+        }
+        return result != nil
+    }
+    
+    func fetchAll<T>(_ type: T.Type) -> Results<T>? where T : Object {
+        let results = realm?.objects(T.self)
+        return results
+    }
+    
+    func fetchById<T>(id: ObjectId, _ type: T.Type) -> T? where T : Object {
+        let result = realm?.object(ofType: T.self, forPrimaryKey: id)
+        return result
+    }
+    
+    func delete<T: Object>(id: ObjectId, _ type: T.Type) -> Bool {
+        guard let model = fetchById(id: id, type),
+              !model.isInvalidated else {
+            return false
+        }
+        
+        let result: ()? = try? realm?.write({
+            realm?.delete(model)
+        })
+        return result != nil
+    }
+}

--- a/PomoLog/Models/PomodoroModel.swift
+++ b/PomoLog/Models/PomodoroModel.swift
@@ -18,20 +18,20 @@ final class PomodoroModel: Object {
     var id: ObjectId = ObjectId.generate()
     
     @Persisted
-    var goal: String = ""
+    var goal: String
     
     @Persisted
-    var csf: String = ""
+    var csf: String
     
     @Persisted
     var summaries: List<String>
     
     @Persisted
-    var timestamp: Date = Date()
+    var timestamp: Date
     
     @Persisted
-    var dateString: String = ""
+    var dateString: String
     
     @Persisted
-    var focusTime: Int = 0
+    var focusTime: Int
 }

--- a/PomoLog/Models/PomodoroModel.swift
+++ b/PomoLog/Models/PomodoroModel.swift
@@ -1,0 +1,37 @@
+//
+//  PomodoroModel.swift
+//  PomoLog
+//
+//  Created by APPLE on 12/18/25.
+//
+
+import Foundation
+
+import RealmSwift
+
+final class PomodoroModel: Object {
+    
+    // @objc dynamic -> @Persisted (프로퍼티 래퍼)
+    // id : Int -> ObjectId
+    
+    @Persisted(primaryKey: true)
+    var id: ObjectId = ObjectId.generate()
+    
+    @Persisted
+    var goal: String = ""
+    
+    @Persisted
+    var csf: String = ""
+    
+    @Persisted
+    var summaries: List<String>
+    
+    @Persisted
+    var timestamp: Date = Date()
+    
+    @Persisted
+    var dateString: String = ""
+    
+    @Persisted
+    var focusTime: Int = 0
+}

--- a/PomoLog/Models/SummaryModel.swift
+++ b/PomoLog/Models/SummaryModel.swift
@@ -1,0 +1,22 @@
+//
+//  SummaryModel.swift
+//  PomoLog
+//
+//  Created by APPLE on 12/18/25.
+//
+
+import Foundation
+
+import RealmSwift
+
+final class SummaryModel: Object {
+    
+    @Persisted(primaryKey: true)
+    var id: ObjectId = ObjectId.generate()
+    
+    @Persisted
+    var content: String = ""
+    
+    @Persisted
+    var timestamp: Date = Date()
+}

--- a/PomoLog/Models/SummaryModel.swift
+++ b/PomoLog/Models/SummaryModel.swift
@@ -15,8 +15,8 @@ final class SummaryModel: Object {
     var id: ObjectId = ObjectId.generate()
     
     @Persisted
-    var content: String = ""
+    var content: String
     
     @Persisted
-    var timestamp: Date = Date()
+    var timestamp: Date
 }

--- a/PomoLogTest/RealmTest.swift
+++ b/PomoLogTest/RealmTest.swift
@@ -1,0 +1,86 @@
+//
+//  PomoLogTest.swift
+//  PomoLogTest
+//
+//  Created by APPLE on 12/18/25.
+//
+
+import Foundation
+import Testing
+
+import RealmSwift
+
+@testable import PomoLog
+
+struct RealmTest {
+
+    @Test("SummaryModel을 DB에 저장")
+    func save_summaryModel__success() {
+        let realmManager = createRealmManager()
+        let model = createSummaryModel()
+        
+        let isSaved = realmManager.save(model: model)
+        
+        #expect(isSaved)
+    }
+    
+    @Test("같은 id의 SummaryModel을 DB에 저장하면 기존 데이터 수정")
+    func update_summaryModel__success() {
+        let realmManager = createRealmManager()
+        let model = createSummaryModel()
+        let _ = realmManager.save(model: model)
+        
+        let newModel = createSummaryModel()
+        newModel.id = model.id
+        newModel.content = "content"
+        let isSaved = realmManager.save(model: newModel)
+        
+        #expect(isSaved)
+        #expect(realmManager.fetchAll(SummaryModel.self)?.count == .some(1))
+    }
+    
+    @Test("DB에서 요약 데이터 전체 조회")
+    func fetchAll_summaries__success() throws {
+        let realmManager = createRealmManager()
+        let model = createSummaryModel()
+        let _ = realmManager.save(model: model)
+        
+        let result = try #require(realmManager.fetchAll(SummaryModel.self)?.first)
+        
+        #expect(result == model)
+    }
+    
+    @Test("DB에서 id 기반 요약 데이터 조회")
+    func fetchById_summary__success() throws {
+        let realmManager = createRealmManager()
+        let model = createSummaryModel()
+        let _ = realmManager.save(model: model)
+        
+        let result = try #require(realmManager.fetchById(id: model.id, SummaryModel.self))
+        
+        #expect(result == model)
+    }
+    
+    @Test("DB에서 id 기반 요약 데이터 삭제")
+    func delete_summary__success() throws {
+        let realmManager = createRealmManager()
+        let model = createSummaryModel()
+        let _ = realmManager.save(model: model)
+        
+        let isDeleted = realmManager.delete(id: model.id, SummaryModel.self)
+        
+        #expect(isDeleted)
+    }
+    
+    private func createRealmManager() -> RealmManager {
+        let configuration = Realm.Configuration(inMemoryIdentifier: UUID().uuidString)
+        let realm = try? Realm(configuration: configuration)
+        let realmManager = RealmManager(realm: realm)
+        
+        return realmManager
+    }
+    
+    private func createSummaryModel() -> SummaryModel {
+        .init()
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #7 

## 📄 작업 내용
- [ ] Realm 연동
- [ ] PomodoroModel, SummaryModel 생성
- [ ] Realm CRUD를 담당하는 매니저 클래스 생성
- [ ] CRUD 테스트코드 작성

## 💻 주요 코드 설명
`DataBase`
- CRUD 프로토콜 제작
```swift
protocol DataBase {
    
    func save<T: Object>(model: T) -> Bool
    func fetchAll<T: Object>(_ type: T.Type) -> Results<T>?
    func fetchById<T: Object>(id: ObjectId, _ type: T.Type) -> T?
    func delete<T: Object>(id: ObjectId, _ type: T.Type) -> Bool
}
```

`SummaryModel`
- 모델 생성
```swift
final class SummaryModel: Object {
    
    @Persisted(primaryKey: true)
    var id: ObjectId = ObjectId.generate()
    
    @Persisted
    var content: String
    
    @Persisted
    var timestamp: Date
}
```

`RealmTest`
- CRUD 테스트코드 작성
```swift
struct RealmTest {

    @Test("SummaryModel을 DB에 저장")
    func save_summaryModel__success() {
        let realmManager = createRealmManager()
        let model = createSummaryModel()
        
        let isSaved = realmManager.save(model: model)
        
        #expect(isSaved)
    }
}

// 다른 테스트 생략
```