### PR TITLE
Feat/#9 Realm 저장/수정 로직 연동

### DIFF
--- a/PomoLog.xcodeproj/project.pbxproj
+++ b/PomoLog.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Data/DataBase.swift,
+				Data/RealmFactory.swift,
 				Data/RealmManager.swift,
 				Models/SummaryModel.swift,
 			);

--- a/PomoLog/App/String+.swift
+++ b/PomoLog/App/String+.swift
@@ -1,0 +1,8 @@
+//
+//  Errors.swift
+//  PomoLog
+//
+//  Created by APPLE on 12/19/25.
+//
+
+extension String: Error {}

--- a/PomoLog/Data/DataBase.swift
+++ b/PomoLog/Data/DataBase.swift
@@ -10,6 +10,7 @@ import RealmSwift
 protocol DataBase {
     
     func save<T: Object>(model: T) -> Bool
+    func update<T: Object>(model: T, action: () -> Void) -> Bool
     func fetchAll<T: Object>(_ type: T.Type) -> Results<T>?
     func fetchById<T: Object>(id: ObjectId, _ type: T.Type) -> T?
     func delete<T: Object>(id: ObjectId, _ type: T.Type) -> Bool

--- a/PomoLog/Data/RealmFactory.swift
+++ b/PomoLog/Data/RealmFactory.swift
@@ -1,0 +1,21 @@
+//
+//  RealmFactory.swift
+//  PomoLog
+//
+//  Created by APPLE on 12/19/25.
+//
+
+import RealmSwift
+
+final class RealmFactory {
+    
+    static let shared = RealmFactory()
+    
+    private let configuration = Realm.Configuration.defaultConfiguration
+    
+    private init() {}
+    
+    func createRealm() -> Realm? {
+        return try? Realm(configuration: configuration)
+    }
+}

--- a/PomoLog/Data/RealmManager.swift
+++ b/PomoLog/Data/RealmManager.swift
@@ -11,13 +11,12 @@ final class RealmManager: DataBase {
     
     private let realm: Realm?
     
-    init(realm: Realm? = try? Realm()) {
+    init(realm: Realm? = RealmFactory.shared.createRealm()) {
         self.realm = realm
     }
     
     func save<T>(model: T) -> Bool where T : Object {
         let result: ()? = try? realm?.write {
-            // 이미 id가 존재하면 업데이트
             realm?.add(model, update: .modified)
         }
         return result != nil

--- a/PomoLog/Data/RealmManager.swift
+++ b/PomoLog/Data/RealmManager.swift
@@ -22,6 +22,13 @@ final class RealmManager: DataBase {
         return result != nil
     }
     
+    func update<T>(model: T, action: () -> Void) -> Bool where T : Object {
+        let result: Void? = try? realm?.write({
+            action()
+        })
+        return result != nil
+    }
+    
     func fetchAll<T>(_ type: T.Type) -> Results<T>? where T : Object {
         let results = realm?.objects(T.self)
         return results

--- a/PomoLog/Models/PomodoroModel.swift
+++ b/PomoLog/Models/PomodoroModel.swift
@@ -24,7 +24,10 @@ final class PomodoroModel: Object {
     var csf: String
     
     @Persisted
-    var summaries: List<String>
+    var output: String
+    
+    @Persisted
+    var summaries: List<SummaryModel>
     
     @Persisted
     var timestamp: Date

--- a/PomoLog/Presentation/Enums/FocusStep.swift
+++ b/PomoLog/Presentation/Enums/FocusStep.swift
@@ -14,6 +14,8 @@ enum FocusStep: Int {
     case shortBreak
     case longBreak
     
+    static var focusTime: Int = 24
+    
     var title: String {
         switch self {
         case .focus:

--- a/PomoLog/Presentation/Enums/FocusStep.swift
+++ b/PomoLog/Presentation/Enums/FocusStep.swift
@@ -14,7 +14,7 @@ enum FocusStep: Int {
     case shortBreak
     case longBreak
     
-    static var focusTime: Int = 24
+    static var focusTime: Int = 24 * 60
     
     var title: String {
         switch self {
@@ -42,22 +42,18 @@ enum FocusStep: Int {
         }
     }
     
-    // focus : 24
-    // focusSummary : 1
-    // shortBreak : 5
-    // longBreak : 25
     var totalTime: Int {
         let seconds = 60
         
         switch self {
         case .focus:
-            return 2
+            return 24 * seconds
         case .focusSummary:
-            return 10
+            return 1 * seconds
         case .shortBreak:
-            return 2
+            return 5 * seconds
         case .longBreak:
-            return 2
+            return 25 * seconds
         }
     }
 }

--- a/PomoLog/Presentation/Features/Focus/Goal/GoalView.swift
+++ b/PomoLog/Presentation/Features/Focus/Goal/GoalView.swift
@@ -7,12 +7,28 @@
 
 import SwiftUI
 
+import RealmSwift
+
 struct GoalView: View {
     
     let selectTabAction: (Int) -> Void
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월 dd일"
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        return formatter
+    }()
     
-    @State private var goal = ""
-    @State private var csf = ""
+    @State private var goal: String = ""
+    @State private var csf: String = ""
+    @State private var output: String = ""
+    @State private var shouldNavigate: Bool = false
+    @State private var pomodoroID: ObjectId = ObjectId()
+    private var canMoveToTimer: Bool {
+        !goal.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        && !csf.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        && !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
     
     init(selectTabAction: @escaping (Int) -> Void) {
         self.selectTabAction = selectTabAction
@@ -46,17 +62,18 @@ struct GoalView: View {
                             placeHolder: "목표 달성을 위한 핵심 성공 요인은 무엇인가요?",
                             text: $csf
                         )
+                        
+                        TextFieldView(
+                            title: "아웃풋",
+                            placeHolder: "목표를 달성하면 어떤 결과물이 나올까요?",
+                            text: $output
+                        )
                     }
                     .frame(maxWidth: 720, alignment: .leading)
                     .padding(.horizontal)
                     
-                    NavigationLink {
-                        PomodoroTimerView(
-                            cycle: .first,
-                            focusStep: .focus,
-                            goal: $goal.wrappedValue,
-                            selectTabAction: selectTabAction
-                        )
+                    Button {
+                        savePomodoro()
                     } label: {
                         HStack(spacing: 10) {
                             Image(systemName: "play.fill")

--- a/PomoLog/Presentation/Features/Focus/Goal/GoalView.swift
+++ b/PomoLog/Presentation/Features/Focus/Goal/GoalView.swift
@@ -40,7 +40,7 @@ struct GoalView: View {
                 Color.white.ignoresSafeArea()
                 
                 VStack(spacing: 20) {
-                    Spacer(minLength: 24)
+                    Spacer(minLength: 40)
                     
                     VStack(alignment: .leading, spacing: 6) {
                         Text("집중할 목표를 설정해보세요")
@@ -83,15 +83,24 @@ struct GoalView: View {
                         }
                         .padding(.vertical, 12)
                         .frame(maxWidth: 240)
-                        .background(canMoveTimer ? .enableStart : .gray)
+                        .background(canMoveToTimer ? .enableStart : .gray)
                         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                         .foregroundColor(.white)
                     }
                     .buttonStyle(PlainButtonStyle())
                     .shadow(radius: 1)
-                    .disabled(!canMoveTimer)
+                    .disabled(!canMoveToTimer)
+                    .navigationDestination(isPresented: $shouldNavigate) {
+                        PomodoroTimerView(
+                            cycle: .first,
+                            focusStep: .focus,
+                            goal: $goal.wrappedValue,
+                            selectTabAction: selectTabAction,
+                            pomodoroID: pomodoroID
+                        )
+                    }
                     
-                    Spacer()
+                    Spacer(minLength: 40)
                 }
                 .padding(.vertical, 28)
                 .padding(.horizontal, 16)
@@ -100,8 +109,19 @@ struct GoalView: View {
         }
     }
     
-    private var canMoveTimer: Bool {
-        !goal.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        && !csf.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    private func savePomodoro() {
+        let realmManager = RealmManager()
+        
+        let pomodoro = PomodoroModel()
+        pomodoro.goal = goal
+        pomodoro.csf = csf
+        pomodoro.output = output
+        pomodoro.dateString = dateFormatter.string(from: pomodoro.timestamp)
+        pomodoroID = pomodoro.id
+        
+        let isSaved = realmManager.save(model: pomodoro)
+        if isSaved {
+            shouldNavigate = true
+        }
     }
 }

--- a/PomoLog/Presentation/Features/Focus/Timer/PomodoroTimerView.swift
+++ b/PomoLog/Presentation/Features/Focus/Timer/PomodoroTimerView.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+import RealmSwift
+
 struct PomodoroTimerView: View {
     
     @State var cycle: Cycle
@@ -14,6 +16,7 @@ struct PomodoroTimerView: View {
     @State var showPopUp: Bool = false
     let goal: String
     let selectTabAction: (Int) -> Void
+    let pomodoroID: ObjectId
     
     var body: some View {
         ZStack {
@@ -29,7 +32,8 @@ struct PomodoroTimerView: View {
                     TimerView(
                         cycle: $cycle,
                         focusStep: $focusStep,
-                        selectTabAction: selectTabAction
+                        selectTabAction: selectTabAction,
+                        pomodoroID: pomodoroID
                     )
                 }
                 

--- a/PomoLog/Presentation/Features/Focus/Timer/TimerView.swift
+++ b/PomoLog/Presentation/Features/Focus/Timer/TimerView.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+import RealmSwift
+
 struct TimerView: View {
     
     private let seconds: Int = 60
@@ -16,6 +18,7 @@ struct TimerView: View {
     @Binding var focusStep: FocusStep
     @State var remainingTime: Int
     let selectTabAction: (Int) -> Void
+    let pomodoroID: ObjectId
     
     @State var timer: Timer?
     @State var isEnabled: Bool = false
@@ -24,12 +27,14 @@ struct TimerView: View {
     init(
         cycle: Binding<Cycle>,
         focusStep: Binding<FocusStep>,
-        selectTabAction: @escaping (Int) -> Void
+        selectTabAction: @escaping (Int) -> Void,
+        pomodoroID: ObjectId
     ) {
         self._cycle = cycle
         self._focusStep = focusStep
         self._remainingTime = State(initialValue: focusStep.wrappedValue.totalTime)
         self.selectTabAction = selectTabAction
+        self.pomodoroID = pomodoroID
     }
     
     var body: some View {
@@ -62,6 +67,7 @@ struct TimerView: View {
                         Button {
                             focusStep = PomodoroSchedular.shared.getNextStep()
                             remainingTime = focusStep.totalTime
+                            saveSummary()
                         } label: {
                             HStack {
                                 Text("완료하기")
@@ -130,5 +136,25 @@ struct TimerView: View {
         isEnabled = false
         timer?.invalidate()
         timer = nil
+    }
+    
+    private func saveSummary() {
+        let realmManager = RealmManager()
+        
+        let summaryModel = SummaryModel()
+        summaryModel.content = summary
+        
+        let isSaved = realmManager.save(model: summaryModel)
+        
+        if isSaved {
+            guard let fetchedPomodoroModel = realmManager.fetchById(id: pomodoroID, PomodoroModel.self) else {
+                return
+            }
+            
+            let _ = realmManager.update(model: fetchedPomodoroModel) {
+                fetchedPomodoroModel.summaries.append(summaryModel)
+                fetchedPomodoroModel.focusTime += FocusStep.focusTime
+            }
+        }
     }
 }

--- a/PomoLog/Presentation/Features/Focus/Timer/TimerView.swift
+++ b/PomoLog/Presentation/Features/Focus/Timer/TimerView.swift
@@ -95,6 +95,9 @@ struct TimerView: View {
                         TimerButton(
                             action: {
                                 stopTimer()
+                                if focusStep == .focus {
+                                    updateFocusTime(remainingTime: remainingTime)
+                                }
                                 selectTabAction(1)
                             },
                             imageName: "stop.fill"
@@ -129,6 +132,9 @@ struct TimerView: View {
             if focusStep == .focus {
                 cycle = cycle.update()
             }
+            if focusStep == .focusSummary {
+                updateFocusTime()
+            }
         }
     }
     
@@ -153,8 +159,31 @@ struct TimerView: View {
             
             let _ = realmManager.update(model: fetchedPomodoroModel) {
                 fetchedPomodoroModel.summaries.append(summaryModel)
-                fetchedPomodoroModel.focusTime += FocusStep.focusTime
             }
+        }
+    }
+    
+    private func updateFocusTime() {
+        let realmManager = RealmManager()
+        
+        guard let fetchedPomodoroModel = realmManager.fetchById(id: pomodoroID, PomodoroModel.self) else {
+            return
+        }
+        
+        let _ = realmManager.update(model: fetchedPomodoroModel) {
+            fetchedPomodoroModel.focusTime += FocusStep.focusTime
+        }
+    }
+    
+    private func updateFocusTime(remainingTime: Int) {
+        let realmManager = RealmManager()
+        
+        guard let fetchedPomodoroModel = realmManager.fetchById(id: pomodoroID, PomodoroModel.self) else {
+            return
+        }
+        
+        let _ = realmManager.update(model: fetchedPomodoroModel) {
+            fetchedPomodoroModel.focusTime += FocusStep.focusTime - remainingTime
         }
     }
 }

--- a/PomoLogTest/RealmTest.swift
+++ b/PomoLogTest/RealmTest.swift
@@ -25,7 +25,7 @@ struct RealmTest {
     }
     
     @Test("같은 id의 SummaryModel을 DB에 저장하면 기존 데이터 수정")
-    func update_summaryModel__success() {
+    func save_same_summaryModel__success() {
         let realmManager = createRealmManager()
         let model = createSummaryModel()
         let _ = realmManager.save(model: model)
@@ -37,6 +37,21 @@ struct RealmTest {
         
         #expect(isSaved)
         #expect(realmManager.fetchAll(SummaryModel.self)?.count == .some(1))
+    }
+    
+    @Test("기존 SummaryModel의 속성 수정")
+    func update_summaryModel__success() throws {
+        let realmManager = createRealmManager()
+        let model = createSummaryModel()
+        let _ = realmManager.save(model: model)
+        
+        let fetchedModel = try #require(realmManager.fetchById(id: model.id, SummaryModel.self))
+        let isUpdated = realmManager.update(model: fetchedModel) {
+            fetchedModel.content = "요약"
+        }
+        
+        #expect(isUpdated)
+        #expect(realmManager.fetchById(id: model.id, SummaryModel.self)?.content == .some("요약"))
     }
     
     @Test("DB에서 요약 데이터 전체 조회")


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #9 

## 📄 작업 내용
- [ ] 목표, CSF, 아웃풋 저장 로직 구현
- [ ] 요약 완료 시 저장 로직 구현
- [ ] 타이머 정지 / 요약 진입에 따른 집중 시간 업데이트 로직 구현