### PR TITLE
feat: #17 포모도로 기록 삭제 기능 구현

### DIFF
--- a/PomoLog/Models/PomodoroModel.swift
+++ b/PomoLog/Models/PomodoroModel.swift
@@ -9,7 +9,7 @@ import Foundation
 
 import RealmSwift
 
-final class PomodoroModel: Object {
+final class PomodoroModel: Object, Identifiable {
     
     // @objc dynamic -> @Persisted (프로퍼티 래퍼)
     // id : Int -> ObjectId

--- a/PomoLog/Presentation/Extensions/Image+.swift
+++ b/PomoLog/Presentation/Extensions/Image+.swift
@@ -16,4 +16,5 @@ extension Image {
     static let previous = Image(systemName: "arrow.backward.circle")
     static let next = Image(systemName: "arrow.forward.circle")
     static let dropDown = Image(systemName: "arrowtriangle.down.circle")
+    static let remove = Image(systemName: "trash")
 }

--- a/PomoLog/Presentation/Features/Focus/Timer/ProgressBarView.swift
+++ b/PomoLog/Presentation/Features/Focus/Timer/ProgressBarView.swift
@@ -16,7 +16,7 @@ struct ProgressBarView: View {
     
     var body: some View {
         HStack(spacing: 10) {
-            ForEach(0..<Cycle.allCases.count) { index in
+            ForEach(0..<Cycle.allCases.count, id: \.self) { index in
                 RoundedRectangle(cornerRadius: 10)
                     .frame(width: 50, height: 10)
                     .foregroundStyle(index <= timerManager.cycle.rawValue ? .gray : .lightGray)

--- a/PomoLog/Presentation/Features/Review/Calendar/GridView.swift
+++ b/PomoLog/Presentation/Features/Review/Calendar/GridView.swift
@@ -28,7 +28,7 @@ struct GridView: View {
                 let daysInMonth = numberOfDays(in: self.month)
                 let firstWeekDay = firstWeekdayOfMonth(in: self.month) - 1
                 
-                ForEach(0 ..< daysInMonth + firstWeekDay, id: \.self) {
+                ForEach(0..<daysInMonth + firstWeekDay, id: \.self) {
                     initCalendarCell(index: $0, firstWeekday: firstWeekDay)
                 }
             }

--- a/PomoLog/Presentation/Features/Review/PomodoroRecord/PomodoroCardHeaderView.swift
+++ b/PomoLog/Presentation/Features/Review/PomodoroRecord/PomodoroCardHeaderView.swift
@@ -7,25 +7,50 @@
 
 import SwiftUI
 
+import RealmSwift
+
 struct PomodoroCardHeaderView: View {
     
     let index: Int
     let formattedTime: String
+    let pomodoroID: ObjectId
+    var onRemove: () -> Void
     
     var body: some View {
         HStack {
             Text("\(index + 1)")
                 .font(.system(size: 12, weight: .bold))
                 .frame(width: 22, height: 22)
-                .background(Circle().fill(.black))
+                .background(Circle().fill(.focus))
                 .foregroundStyle(.white)
             
             Text(formattedTime)
                 .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(.focus)
             
             Spacer()
+            
+            Button {
+                removePomodoro()
+            } label: {
+                Image.remove
+                    .foregroundStyle(.remove)
+            }
+            .buttonStyle(PlainButtonStyle())
         }
         .padding()
         .background(Color.gray.opacity(0.05))
+    }
+}
+
+extension PomodoroCardHeaderView {
+    
+    func removePomodoro() {
+        let realmManager = PomodoroRealmManager()
+        let isRemoved = realmManager.delete(id: pomodoroID, PomodoroModel.self)
+        
+        if isRemoved {
+            onRemove()
+        }
     }
 }

--- a/PomoLog/Presentation/Features/Review/PomodoroRecord/PomodoroCardView.swift
+++ b/PomoLog/Presentation/Features/Review/PomodoroRecord/PomodoroCardView.swift
@@ -12,18 +12,22 @@ struct PomodoroCardView: View {
     let index: Int
     let pomodoro: PomodoroModel
     let formattedTime: String
+    var onRemove: () -> Void
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             PomodoroCardHeaderView(
                 index: index,
-                formattedTime: formattedTime
+                formattedTime: formattedTime,
+                pomodoroID: pomodoro.id,
+                onRemove: onRemove
             )
             
             GoalAndSummariesView(
                 goal: pomodoro.goal,
                 summaries: pomodoro.summaries
             )
+            .padding(.top, 8)
             .padding([.horizontal, .bottom], 16)
         }
         .background(Color.white)

--- a/PomoLog/Presentation/Features/Review/PomodoroRecord/ShowPomodorosView.swift
+++ b/PomoLog/Presentation/Features/Review/PomodoroRecord/ShowPomodorosView.swift
@@ -16,6 +16,7 @@ struct ShowPomodorosView: View {
     private let hourUnit: String = "시간"
     private let minuteUnit: String = "분"
     private let secondUnit: String = "초"
+    @State private var refreshID = UUID()
     
     let pomodoros: Results<PomodoroModel>
     
@@ -26,10 +27,12 @@ struct ShowPomodorosView: View {
                     PomodoroCardView(
                         index: index,
                         pomodoro: pomodoro,
-                        formattedTime: formatTime(pomodoro.focusTime)
-                    )
+                        formattedTime: formatTime(pomodoro.focusTime)) {
+                            refreshID = UUID()
+                        }
                 }
             }
+            .id(refreshID)
             .padding()
         }
         .background(.ultraThinMaterial)

--- a/PomoLog/Resources/Assets.xcassets/Color/remove.colorset/Contents.json
+++ b/PomoLog/Resources/Assets.xcassets/Color/remove.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x67",
+          "green" : "0x5D",
+          "red" : "0xAF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #17  

## 📄 작업 내용
- 포모도로 기록 삭제 기능 구현

|    구현 내용    |  Mac   |
| :-------------: | :----------: |
| 기록 삭제 | <img src = "https://github.com/user-attachments/assets/10edf176-61d0-443d-b5de-225dbf45cf0b" width ="500"> |

## 💻 주요 코드 설명
`PomodoroCardHeaderview`
- Realm을 활용하여 포모도로 기록 삭제
```swift
extension PomodoroCardHeaderView {
    
    func removePomodoro() {
        let realmManager = PomodoroRealmManager()
        let isRemoved = realmManager.delete(id: pomodoroID, PomodoroModel.self)
        
        if isRemoved {
            onRemove()
        }
    }
}
```

`ShowPomodorosView`
- onRemove 클로저가 호출되었을 때 뷰를 다시 그리는 동작 구현
```swift
struct ShowPomodorosView {
    
    // 생략
    var body: some View {
        ScrollView {
            VStack(spacing: 20) {
                ForEach(Array(pomodoros.enumerated()), id: \.offset) { index, pomodoro in
                    PomodoroCardView(
                        index: index,
                        pomodoro: pomodoro,
                        formattedTime: formatTime(pomodoro.focusTime)) {
                            refreshID = UUID()
                        }
                }
            }
            .id(refreshID)
            .padding()
        }
        .background(.ultraThinMaterial)
    }
}
```